### PR TITLE
Code formatting and support for svelte blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1464,7 +1464,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
       "integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
-      "dev": true,
       "optional": true,
       "requires": {
         "good-listener": "^1.2.2",
@@ -1783,7 +1782,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
       "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "dev": true,
       "optional": true
     },
     "depd": {
@@ -2296,7 +2294,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "dev": true,
       "optional": true,
       "requires": {
         "delegate": "^3.1.2"
@@ -3300,11 +3297,15 @@
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
       "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
     },
+    "prism-svelte": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/prism-svelte/-/prism-svelte-0.4.6.tgz",
+      "integrity": "sha512-C4U7thaRBDqtWu0H/8+NjBri4wKzzzJ5PULQFL8ZBCjYjniFvRNUEDldXpt4GWAi0vkrc1Uho3PVyCiXg9mCYg=="
+    },
     "prismjs": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.20.0.tgz",
       "integrity": "sha512-AEDjSrVNkynnw6A+B1DsFkd6AVdTnp+/WoUixFRULlCLZVRZlVQMVWio/16jv7G1FscUxQxOQhWwApgbnxr6kQ==",
-      "dev": true,
       "requires": {
         "clipboard": "^2.0.0"
       }
@@ -3860,7 +3861,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "dev": true,
       "optional": true
     },
     "semver": {
@@ -4210,7 +4210,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "dev": true,
       "optional": true
     },
     "to-fast-properties": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
   "dependencies": {
     "@rollup/plugin-replace": "^2.3.3",
     "@sveltech/routify": "^1.9.0",
+    "prism-svelte": "^0.4.6",
+    "prismjs": "^1.20.0",
     "rollup-plugin-workbox": "^5.0.1",
     "svelte": "^3.23.2",
     "workbox": "0.0.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,6 @@
+import Prism from 'prismjs';
+import 'prism-svelte';
+
 import svelte from 'rollup-plugin-svelte-hot';
 import Hmr from 'rollup-plugin-hot'
 import resolve from '@rollup/plugin-node-resolve';

--- a/src/pages/recipes/_layout.svelte
+++ b/src/pages/recipes/_layout.svelte
@@ -50,7 +50,9 @@
 
 <svelte:head>
   <title>Svelte Recipes</title>
+  <link rel="stylesheet" href="/prism.css">
 </svelte:head>
+
 <main>
   <div class="TOC">
     <h1>table of contents</h1>

--- a/static/global.css
+++ b/static/global.css
@@ -147,7 +147,6 @@
   }
   
   /* Typography */
-  code,
   samp {
 	background-color: var(--color-accent);
 	border-radius: var(--border-radius);
@@ -198,11 +197,6 @@
 	padding: 0;
   }
   
-  pre {
-	white-space: normal;
-  }
-  
-  pre code,
   pre samp {
 	display: block;
 	margin: 1rem 0;

--- a/static/prism.css
+++ b/static/prism.css
@@ -6,8 +6,8 @@
 
 /*	colors --------------------------------- */
 pre[class*='language-'] {
-	--background: hsl(45, 7%, 5%);
-	--base:       hsl(173, 80%, 98%);
+	--background: #f6fafd;
+	--base:       hsl(45, 7%, 45%);
 	--comment:    hsl(210, 25%, 60%);
 	--keyword:    hsl(204, 58%, 45%);
 	--function:   hsl(19, 67%, 45%);
@@ -41,8 +41,7 @@ pre[class*='language-'] {
 	margin: .8rem 0 2.4rem;
 	/* max-width: var(--code-w); */
 	border-radius: var(--border-r);
-    box-shadow: 1px 1px 1px rgba(68, 68, 68, .12) inset;
-    white-space: normal;
+	box-shadow: 1px 1px 1px rgba(68, 68, 68, .12) inset;
 }
 
 :not(pre) > code[class*='language-'],

--- a/static/prism.css
+++ b/static/prism.css
@@ -42,6 +42,7 @@ pre[class*='language-'] {
 	/* max-width: var(--code-w); */
 	border-radius: var(--border-r);
 	box-shadow: 1px 1px 1px rgba(68, 68, 68, .12) inset;
+	white-space: normal;
 }
 
 :not(pre) > code[class*='language-'],

--- a/static/prism.css
+++ b/static/prism.css
@@ -1,0 +1,97 @@
+/*
+-----------------------------------------------
+	syntax-highlighting [prism]
+-----------------------------------------------
+*/
+
+/*	colors --------------------------------- */
+pre[class*='language-'] {
+	--background: hsl(45, 7%, 5%);
+	--base:       hsl(173, 80%, 98%);
+	--comment:    hsl(210, 25%, 60%);
+	--keyword:    hsl(204, 58%, 45%);
+	--function:   hsl(19, 67%, 45%);
+	--string:     hsl(41, 37%, 45%);
+	--number:     hsl(102, 27%, 50%);
+	--tags:       var(--function);
+	--important:  var(--string);
+}
+
+/*	type-base ------------------------------ */
+code[class*='language-'],
+pre[class*='language-'] {
+	background: none;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	word-wrap: normal;
+	font: 300 var(--code-fs)/1.7 var(--font-mono);
+	color: var(--base);
+	tab-size: 2;
+	-moz-tab-size: 2;
+	-webkit-hyphens: none;
+	hyphens: none;
+}
+
+/*	code-blocks ---------------------------- */
+pre[class*='language-'] {
+	overflow: auto;
+	padding: 1.5rem 2rem;
+	margin: .8rem 0 2.4rem;
+	/* max-width: var(--code-w); */
+	border-radius: var(--border-r);
+    box-shadow: 1px 1px 1px rgba(68, 68, 68, .12) inset;
+    white-space: normal;
+}
+
+:not(pre) > code[class*='language-'],
+pre[class*='language-'] {
+	background: var(--background);
+}
+
+/*	tokens --------------------------------- */
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata       { color: var(--comment) }
+
+.token.punctuation { color: var(--base) }
+
+.token.property,
+.token.tag,
+.token.constant,
+.token.symbol,
+.token.deleted      { color: var(--tags) }
+
+.token.boolean,
+.token.number       { color: var(--number) }
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted      { color: var(--string) }
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string,
+.token.variable       { color: var(--base) }
+
+.token.atrule,
+.token.attr-value,
+.token.function,
+.token.class-name     { color: var(--function) }
+
+.token.keyword        { color: var(--keyword) }
+
+.token.regex,
+.token.important      { color: var(--important) }
+
+.token.important,
+.token.bold   { font-weight: bold }
+.token.italic { font-style: italic }
+.token.entity { cursor: help }


### PR DESCRIPTION
- Adds support for ```svelte fenced blocks
- Introduces a styling similar to the one used svelte.dev/docs for the code snippets in the recipes

Closes #28 