### PR TITLE
Make code blocks and inline code monospace

### DIFF
--- a/static/global.css
+++ b/static/global.css
@@ -3,6 +3,7 @@
 :root {
 	--border-radius: 5px;
 	--box-shadow: 2px 2px 10px;
+	--code-fs: 1rem;
 	--color: #ff3e00;
 	--color-accent: #ff3e000b;
 	--color-bg: #fff;
@@ -12,6 +13,7 @@
 	--color-shadow: #f4f4f4;
 	--color-text: #444;
 	--color-text-secondary: #999;
+	--font-mono: 'Fira Mono', monospace;
 	--hover-brightness: 1.2;
 	--justify-important: center;
 	--justify-normal: left;
@@ -384,6 +386,11 @@
 	font-size: small;
 	line-height: var(--line-height);
 	padding: 1.5rem 0;
+  }
+
+  /* Code */
+  code {
+	font-family: var(--font-mono);
   }
   
   /* Custom styles */


### PR DESCRIPTION
Before:
![no-code-style](https://user-images.githubusercontent.com/22732095/88103461-0988f380-cb6f-11ea-8ab5-9895ef3a1ad7.png)

After:
![code-style](https://user-images.githubusercontent.com/22732095/88103486-16a5e280-cb6f-11ea-94b7-17aaeba389ee.png)


These values were taken from the official Svelte site. (Technically the font size was changed to `1rem` because `1.3rem` would've been way too big).