### PR TITLE
Update docker recipe

### DIFF
--- a/src/pages/recipes/publishing-and-deploying/dockerize-a-svelte-app.svx
+++ b/src/pages/recipes/publishing-and-deploying/dockerize-a-svelte-app.svx
@@ -13,58 +13,23 @@ cd svelte-docker
 Next, we need to create a `Dockerfile` in the root of our project.
 
 ```
-FROM node:12-alpine
+FROM node:12 AS build
 
 WORKDIR /app
 
-# copy files and install dependencies
 COPY . ./
 RUN npm install
 RUN npm run build
 
-EXPOSE 5000
-
-CMD ["npm", "start"]
+FROM nginx:1.19-alpine
+COPY --from=build /app/public /usr/share/nginx/html
 ```
 
 You can now build and run your docker image.
 
 ```
 docker build . -t svelte-docker
-docker run -p 5000:5000 svelte-docker
+docker run --rm --name=svelte-docker -p 5000:80 svelte-docker
 ```
 
-Open up your browser at localhost:5000 and you should see your svelte app running!
-
-#### Troubleshooting
-
-On certain operating systems your docker containers IP may not be mapped to `localhost` on your host machine. This means your app won't be served at `localhost`. To see which IP your container is mapped to on your host machine, run your container then execute the following command:
-
-```
-docker inspect <container-id>
-```
-
-In the output, look at the `HostConfig` for the `PortBindings` object.
-
-```json
-"Ports": {
-  "5000/tcp": [
-    {
-      "HostIp": "0.0.0.0",
-      "HostPort": "5000"
-    }
-  ]
-}
-```
-
-Update your `npm start` command to serve your assets on the host IP.
-
-```json
-"scripts": {
-  "build": "rollup -c",
-  "dev": "rollup -c -w",
-  "start": "sirv public --host 0.0.0.0"
-},
-```
-
-Your dockerized svelte app should now be up and running.
+Open up your browser at `http://localhost:5000` and Your dockerized Svelte App should now be up and running!


### PR DESCRIPTION
For issue https://github.com/svelte-society/site/issues/31

Now a two-stage Dockerfile where it copies the build output to an nginx container instead.

Also removed the Troubleshooting section as it didn't seem relevant to nginx.

If you'd like, I can also create a Sapper one in this PR as well?