### PR TITLE
Links in recipe components

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The recipes are written and processed using [Mdsvex](https://mdsvex.com/). Three
 - **Note** To highlight something noteworthy
 - **ReadMore** Use this to wrap extra reading material related to the recipe
 
+**⚠️ Be aware that markup inside of these components will not be processed, so when putting for instance a link inside use normal HTML markup to do so. ⚠️**
+
 ### Example usage
 
 ```md
@@ -29,6 +31,7 @@ title: Sample
 ---
 
 <script>
+  import ReadMore from '../../../components/recipes/ReadMore.svelte'
   import Warning from '../../../components/recipes/Warning.svelte'
 </script>
 
@@ -37,4 +40,8 @@ This is regular text
 <Warning>
     This is text within the block
 </Warning>
+
+<ReadMore>
+  Click <a href="/">here</a> to read more about this.
+</ReadMore>
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The recipes are written and processed using [Mdsvex](https://mdsvex.com/). Three
 - **Note** To highlight something noteworthy
 - **ReadMore** Use this to wrap extra reading material related to the recipe
 
-**⚠️ Be aware that markup inside of these components will not be processed, so when putting for instance a link inside use normal HTML markup to do so. ⚠️**
+**⚠️ Be aware that markdown inside of these components will not be processed, so when putting for instance a link inside use normal HTML markup to do so. ⚠️**
 
 ### Example usage
 

--- a/src/components/recipes/Note.svelte
+++ b/src/components/recipes/Note.svelte
@@ -6,6 +6,21 @@
         margin: 1rem 0;
         padding: .75rem 1.5rem 1rem 1.5rem;
     }
+    
+    div :global(a) {
+        color: inherit;
+        border-bottom: 2px dashed rgb(99,177,249);
+        margin: 0 -3px;
+        padding: 0 3px;
+    }
+    div :global(a:active),
+    div :global(a:focus),
+    div :global(a:hover) {
+        background: rgb(99,177,249);
+        border-bottom: 2px solid black;
+        color: black;
+        text-decoration: none;
+    }
 </style>
 
 <div>

--- a/src/components/recipes/ReadMore.svelte
+++ b/src/components/recipes/ReadMore.svelte
@@ -6,6 +6,21 @@
         margin: 1rem 0;
         padding: .75rem 1.5rem 1rem 1.5rem;
     }
+    
+    div :global(a) {
+        color: inherit;
+        border-bottom: 2px dashed rgb(99,249,105);
+        margin: 0 -3px;
+        padding: 0 3px;
+    }
+    div :global(a:active),
+    div :global(a:focus),
+    div :global(a:hover) {
+        background: rgb(99,249,105);
+        border-bottom: 2px solid black;
+        color: black;
+        text-decoration: none;
+    }
 </style>
 
 <div>

--- a/src/components/recipes/Warning.svelte
+++ b/src/components/recipes/Warning.svelte
@@ -6,6 +6,21 @@
         margin: 1rem 0;
         padding: .75rem 1.5rem 1rem 1.5rem;
     }
+
+    div :global(a) {
+        color: inherit;
+        border-bottom: 2px dashed rgb(255, 62, 1);
+        margin: 0 -3px;
+        padding: 0 3px;
+    }
+    div :global(a:active),
+    div :global(a:focus),
+    div :global(a:hover) {
+        background: rgba(255, 62, 1);
+        border-bottom: 2px solid black;
+        color: black;
+        text-decoration: none;
+    }
 </style>
 
 <div>

--- a/src/pages/recipes/stores/index.svx
+++ b/src/pages/recipes/stores/index.svx
@@ -11,7 +11,7 @@ icon: /images/icons/test.svg
 ## This needs to be re-organised into separate recipes
 
 <Warning>
-This guide assumes you understand the basics of Svelte Stores. If you aren't familiar with them then working through the [relevant tutorial](tutorial/writable-stores) and reading the [store documentation](docs#svelte_store) are highly recommended.
+This guide assumes you understand the basics of Svelte Stores. If you aren't familiar with them then working through the <a href="http://www.svelte.dev/tutorial/writable-stores" target="_blank">relevant tutorial</a> and reading the <a href="http://www.svelte.dev/docs#svelte_store" target="_blank">store documentation</a> are highly recommended.
 </Warning>
 
 Svelte stores offer a simple mechanism to handle shared state in your Svelte application but looking beyond the built-in store implementations will unlock a whole world of power that you could never have dreamed of. In this episode of _The Tinest Kitchen_ we'll take a close look at [The Store Contract](#The_Store_Contract), learn how to implement [Custom Stores](#Custom_Stores), by making use of the built-in store API, and explore how we can implement [a completely custom store]() without using the built-in stores at all.


### PR DESCRIPTION
This styles links inside recipe components (Warning, Note, Readme)
Updated readme to add a comment about how markdown does not work inside components.

see #46 

![image](https://user-images.githubusercontent.com/13446670/89108813-da5e6600-d43b-11ea-9b29-ca1aa963fc15.png)

(all colours have been checked for accessibility contrast stuff)