### PR TITLE
Fix text clipping issue

### DIFF
--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -24,7 +24,7 @@
 
 <style>
   .shaded {
-    width: 100%;
+    max-width: 100%;
     background: #f3f6f9;
   }
   header {


### PR DESCRIPTION
As seen in the screenshot below, the footer text with the Github link is clipping with the current css.  I noticed the width: 100% was causing it to somehow snap to a bigger container than the actual viewport, but removing it or setting it to "max-width: 100%" yields the correct result.

![Screen Shot 2020-09-23 at 20 05 31](https://user-images.githubusercontent.com/55800/94096822-ec280e00-fdd9-11ea-88a9-4e818712c6f9.png)

Correct:

![Screen Shot 2020-09-23 at 20 20 40](https://user-images.githubusercontent.com/55800/94096981-4e810e80-fdda-11ea-85a6-b0cb20550be6.png)
