### PR TITLE
Common widths across pages

### DIFF
--- a/src/pages/recipes/index.svx
+++ b/src/pages/recipes/index.svx
@@ -1,117 +1,108 @@
 <script>
-    import CategoryTree from "@/components/recipes/CategoryTree.svelte";
+  import CategoryTree from "@/components/recipes/CategoryTree.svelte";
 
-    import { getContext } from 'svelte';
-    const categories = getContext("categories")
+  import { getContext } from "svelte";
+  const categories = getContext("categories");
 </script>
 
 <style>
-    .content-wrap {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        width: 100%;
-    }
-    .navigation-block {
-        background: #F3F6F9;
-        width: 100%;
-        padding-bottom: 1rem;
-        margin-bottom: 1rem;
-    }
-    .navigation-content {
-        max-width: 1160px;
-        margin: 0px 0.5rem;
-    }
-    .categories-wrap {
-        display: flex;
-        justify-content: space-evenly;
-        flex-wrap: wrap;
-        padding-top: 1rem;
-    }
+  .content-wrap {
+    align-items: center;
+    width: var(--width-content);
+    margin: 0 auto;
+  }
+  .navigation-block {
+    background: #f3f6f9;
+    padding: 1rem;
+  }
+
+  .categories-wrap {
+    display: flex;
+    justify-content: space-evenly;
+    flex-wrap: wrap;
+    padding-top: 1rem;
+  }
+  .category-style {
+    width: 50%;
+  }
+  @media screen and (max-width: 800px) {
     .category-style {
-        width: 48%;
+      width: 100%;
     }
-    @media screen and (max-width: 800px) {
-        .category-style {
-            width: 100%;
-        }
+    .content-wrap {
+      width: inherit;
     }
-    .signup-block {
-        max-width: 848px;
-        background: #ECF6FF;
-        padding: 0 1.5rem 1.5rem;
-        margin: 1rem 0;
-    }
-    p {
-        max-width: 720px;
-    }
-    p.intro {
-        margin-bottom: 3rem;
-    }
-    h1,
-    h3 {
-        margin-top: 1rem;
-    }
-    button {
-        display: block;
-        margin: 2rem auto 0;
-    }
+  }
+  .signup-block {
+    background: #ecf6ff;
+    padding: 1rem;
+  }
+  button {
+    display: block;
+    margin: 0 auto;
+  }
 </style>
 
 <div class="content-wrap">
-    <div>
-        <h1>Cookbook</h1>
-        <p class="intro">
-            This cookbook serves shows users how best-in-practice
-            code is written in Svelte. You’ll learn how to import
-            third-party libraries, external scripts as well as how to
-            handle common problems that you will have to solve often.
-        </p>
-    </div>
-    <div class="navigation-block">
-        <div class="navigation-content">
-            <h3>Pick a Category to Get Started</h3>
-            <div class="categories-wrap">
-                {#each categories as category}
-                    <div class="category-style">
-                        <div>
-                            <img src={category.meta.frontmatter.icon} alt="" />
-                            <a href={category.parent.path}>{category.meta.frontmatter.title}</a>
-                        </div>
-                        <CategoryTree nodes={category.parent.children} />
-                    </div>
-                {/each}
+  <div class="my-1">
+    <h1>Cookbook</h1>
+    <p class="intro">
+      This cookbook serves shows users how best-in-practice code is written in
+      Svelte. You’ll learn how to import third-party libraries, external scripts
+      as well as how to handle common problems that you will have to solve
+      often.
+    </p>
+  </div>
+  <div class="navigation-block my-1">
+    <div class="navigation-content">
+      <h3>Pick a Category to Get Started</h3>
+      <div class="categories-wrap">
+        {#each categories as category}
+          <div class="category-style">
+            <div>
+              <img src={category.meta.frontmatter.icon} alt="" />
+              <a
+                href={category.parent.path}>{category.meta.frontmatter.title}</a>
             </div>
-        </div>
+            <CategoryTree nodes={category.parent.children} />
+          </div>
+        {/each}
+      </div>
     </div>
-    <div>
-        <h3>
-            What can I expect from these recipes?
-        </h3>
-        <p>
-            The Svelte compiler expects all components it receives to be valid Svelte
-            syntax. To use compile-to-js or compile-to-css languages, you need to make
-            sure that any non-standard syntax is transformed before Svelte tries to parse
-            it. To enable this Svelte provides a preprocess method allowing you to
-            transform different parts of the component before it reaches the compiler.
-            With <b>svelte.preprocess</b> you have a great deal of flexibility in how you write your components while ensuring that the Svelte compiler receives a plain
-            component.
-        </p>
-    </div>
-    <div class="signup-block">
-        <h3>Do you want to write a recipe?</h3>
-        <p>We’re looking for new recipes and recipe authors. Are you interested? Sign up below!</p>
-        <button>Sign up</button>
-    </div>
-    <div>
-        <h3>
-            Where to get started
-        </h3>
-        <p>
-            If you want the quickest way to get started, clone <a href="https://github.com/sveltejs/template">the Official Svelte App template</a>. If you want a custom setup, head to the <a href="/recipes/build-setup">Build Setup recipes</a>.
-        </p>
-        <p>
-            If you are writing a Svelte component library, check the <a href="https://github.com/sveltejs/component-template">the Official Svelte Component template</a>.
-        </p>
-    </div>
+  </div>
+  <div class="my-1">
+    <h3>What can I expect from these recipes?</h3>
+    <p>
+      The Svelte compiler expects all components it receives to be valid Svelte
+      syntax. To use compile-to-js or compile-to-css languages, you need to make
+      sure that any non-standard syntax is transformed before Svelte tries to
+      parse it. To enable this Svelte provides a preprocess method allowing you
+      to transform different parts of the component before it reaches the
+      compiler. With <b>svelte.preprocess</b> you have a great deal of flexibility
+      in how you write your components while ensuring that the Svelte compiler receives
+      a plain component.
+    </p>
+  </div>
+  <div class="signup-block my-1">
+    <h3>Do you want to write a recipe?</h3>
+    <p>
+      We’re looking for new recipes and recipe authors. Are you interested? Sign
+      up below!
+    </p>
+    <button>Sign up</button>
+  </div>
+  <div class="my-1">
+    <h3>Where to get started</h3>
+    <p>
+      If you want the quickest way to get started, clone <a
+        href="https://github.com/sveltejs/template">the Official Svelte App
+        template</a>. If you want a custom setup, head to the <a
+        href="/recipes/build-setup">Build Setup recipes</a>.
+    </p>
+    <p>
+      If you are writing a Svelte component library, check the <a
+        href="https://github.com/sveltejs/component-template">the Official
+        Svelte Component template</a>.
+    </p>
+  </div>
 </div>

--- a/static/global.css
+++ b/static/global.css
@@ -177,12 +177,12 @@
   h4,
   h5,
   h6 {
-	margin-bottom: 0;
+	margin: 0;
 	font-family: Overpass;
 	font-style: normal;
 	font-weight: bold;
 	font-size: 29px;
-	line-height: 150%;
+	line-height: var(--line-height);
   }
   
   mark {
@@ -409,3 +409,9 @@
 	font-weight: bold;
   }
   
+  .my-1{
+	  margin: 1rem 0;
+  }
+  .mx-1{
+	margin: 0 1rem;
+}


### PR DESCRIPTION
Removed several hard-coded properties.

Added new classes `.my-1` and `.mx-1` padding for y and x axes `1rem` respectively.

Full width card for recipes looks distracting and I now have a common width for `recipes` `components` and `about`. 
![ss-ui](https://user-images.githubusercontent.com/3922469/94347458-0b30d500-0052-11eb-97cf-70149d4d4a91.jpg)


Home page remains untouched, 
