### PR TITLE
Update dockerize-a-svelte-app to leverage Docker caching

### DIFF
--- a/src/pages/recipes/publishing-and-deploying/dockerize-a-svelte-app.svx
+++ b/src/pages/recipes/publishing-and-deploying/dockerize-a-svelte-app.svx
@@ -10,6 +10,8 @@ npx degit sveltejs/template svelte-docker
 cd svelte-docker
 ```
 
+Run `npm install` to generate the `package-lock.json` file.
+
 ### Building
 
 Next, we need to create a file named `Dockerfile` in the root of our project, and paste in the following:
@@ -19,8 +21,10 @@ FROM node:12 AS build
 
 WORKDIR /app
 
-COPY . ./
+COPY package.json ./
+COPY package-lock.json ./
 RUN npm install
+COPY . ./
 RUN npm run build
 
 FROM nginx:1.19-alpine
@@ -29,6 +33,12 @@ COPY --from=build /app/public /usr/share/nginx/html
 
 This tells Docker to build the Svelte App using an intermediate Node image and then copies only the build output to the final NGINX image, as
 we only need something that serves static content. That way, Node doesn't contribute to the final size of the Docker image.
+
+To ensure we are not copying unnecessary files and folders in the build process (the `COPY . ./` step), we can add the following to a file named `.dockerignore`:
+
+```
+node_modules
+```
 
 You can now build your docker image:
 


### PR DESCRIPTION
Copying `package.json` and `package-lock.json` and running `npm install` afterwards ensures Docker will cache it. If the dependencies don't change, this will result in faster builds. In the same manner, if for some reason `node_modules` were present in the context where `docker build` is run, we avoid copying them unnecessarily.

If this contribution is accepted, I could also give a shot to the Sapper Dockerfile recipe.

NOTE: I had a look to your contributing guidelines and could not find the `staging` branch, so I assumed using the main branch was probably okay.

Related issue: https://github.com/svelte-society/sveltesociety.dev/issues/31