### PR TITLE
Make components page responsive

### DIFF
--- a/src/components/ComponentIndex/ArrowButton.svelte
+++ b/src/components/ComponentIndex/ArrowButton.svelte
@@ -49,6 +49,14 @@
   div:hover .popin:not(:empty) {
     display: block;
   }
+
+  @media screen and (max-width: 700px) {
+    .popin {
+      left: 1rem;
+      right: 1rem;
+      top: 100%
+    }
+  }
 </style>
 
 <div on:click>

--- a/src/components/ComponentIndex/Card.svelte
+++ b/src/components/ComponentIndex/Card.svelte
@@ -24,10 +24,13 @@
   .card {
     display: flex;
     flex-direction: column;
-    max-width: 370px;
+    max-width: var(--width-card);
     padding: 14px;
     background: #f3f6f9;
     border-radius: 5px;
+  }
+  .card h1 {
+    word-break: break-word;
   }
   .active,
   .card:hover {
@@ -49,6 +52,16 @@
 
   .flex-grow {
     flex-grow: 1;
+  }
+
+  @media screen and (max-width: 400px) {
+    .card {
+      font-size: 0.9rem;
+    }
+
+    .card h1 {
+      font-size: 24px;
+    }
   }
 </style>
 

--- a/src/components/ComponentIndex/CardList.svelte
+++ b/src/components/ComponentIndex/CardList.svelte
@@ -19,6 +19,22 @@
   .list {
     margin-bottom: 5rem;
   }
+
+  @media screen and (max-width: 1024px) {
+    .grid {
+      max-width: calc(var(--width-card) * 2 + 25px);
+      grid-template-columns: repeat(2, 1fr);
+      margin: 0 auto;
+    }
+  }
+
+  @media screen and (max-width: 700px) {
+    .grid {
+      max-width: var(--width-card);
+      grid-template-columns: 1fr;
+      margin: 0 auto;
+    }
+  }
 </style>
 
 <div class="list">

--- a/src/pages/components/index.svelte
+++ b/src/pages/components/index.svelte
@@ -90,6 +90,7 @@
   ul.popin li.tag-search input {
     margin: 0;
     background: #f3f6f9;
+    width: 100%;
   }
   ul.popin li.tag-search:hover {
     background: white;
@@ -105,6 +106,38 @@
   ul.popin li input {
     flex: 0;
     margin: 0 1ex 0 0;
+  }
+
+  @media screen and (max-width: 1024px) {
+    .controls {
+      flex-flow: column-reverse;
+    }
+
+    .inputs {
+      align-self: flex-start;
+      width: 100%;
+      grid-template-columns: repeat(3, auto);
+    }
+
+    .searchbar {
+      align-self: flex-end;
+      margin-bottom: 1ex;
+    }
+  }
+
+  @media screen and (max-width: 700px) {
+    .controls {
+      align-items: stretch;
+    }
+
+    .inputs {
+      grid-template-columns: auto;
+    }
+
+    .searchbar {
+      width: auto;
+      align-self: stretch;
+    }
   }
 </style>
 

--- a/static/global.css
+++ b/static/global.css
@@ -18,7 +18,7 @@
 	--justify-important: center;
 	--justify-normal: left;
 	--line-height: 170%;
-	--width-card: 285px;
+	--width-card: 370px;
 	--width-card-medium: 460px;
 	--width-card-wide: 800px;
 	--width-content: 1166px;


### PR DESCRIPTION
Make the component page responsive as describe in the [Figma](https://www.figma.com/file/CWyNLNaQI4yfHULrf1i4UC/Svelte-Society-Website?node-id=35%3A2)

(Minor change on the **iPhone 11 Pro / X**, each button is on its own line)

Display start to break below 250px, but I don't see who use a such small screen for viewing a webpage.