### PR TITLE
automate the copyright year at the footer

### DIFF
--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -20,6 +20,10 @@
   $: metatags[
     "twitter:description"
   ] = `Svelte Society is a community-driven effort to organise and promote SvelteJS.`;
+
+  // get the year for the copyright statement
+  var date = new Date();
+  var year = date.getFullYear();
 </script>
 
 <style>
@@ -86,7 +90,12 @@
 <slot />
 
 <footer class="shaded">
-  <div>© Svelte Society 2020</div>
+  <div>© Svelte Society {year}</div>
 
-  <div>Want to contribute? Pick up an issue on <a href="https://github.com/svelte-society/sveltesociety.dev" target="_blank">GitHub</a>!</div>
+  <div>
+    Want to contribute? Pick up an issue on
+    <a
+      href="https://github.com/svelte-society/sveltesociety.dev"
+      target="_blank">GitHub</a>!
+  </div>
 </footer>


### PR DESCRIPTION
This little PR makes the footer displaying the current year at the copyright statement. I hope this little change can help. If there are any objections, please let me know.