### PR TITLE
Increase color contrast (a11y)

### DIFF
--- a/assets/global.css
+++ b/assets/global.css
@@ -8,7 +8,7 @@
 	--color-accent: #ff3e000b;
 	--color-bg: #fff;
 	--color-bg-secondary: #e9e9e9;
-	--color-secondary: #40b3ff;
+	--color-secondary: hsl(204, 100%, 38%);
 	--color-secondary-accent: #40b3ff0b;
 	--color-shadow: #f4f4f4;
 	--color-text: #444;

--- a/assets/prism.css
+++ b/assets/prism.css
@@ -7,12 +7,12 @@
 /*	colors --------------------------------- */
 pre[class*='language-'] {
 	--background: #f6fafd;
-	--base:       hsl(45, 7%, 45%);
-	--comment:    hsl(210, 25%, 60%);
-	--keyword:    hsl(204, 58%, 45%);
-	--function:   hsl(19, 67%, 45%);
-	--string:     hsl(41, 37%, 45%);
-	--number:     hsl(102, 27%, 50%);
+	--base:       #545454;
+	--comment:    #696969;
+	--keyword:    #007f8a;
+	--function:   #bb5525;
+	--string:     #856e3d;
+	--number:     #008000;
 	--tags:       var(--function);
 	--important:  var(--string);
 }

--- a/src/components/Introduction.svelte
+++ b/src/components/Introduction.svelte
@@ -21,7 +21,7 @@
     <a
       href="https://github.com/svelte-society/sveltesociety.dev"
       target="_blank">
-      github repository.
+      GitHub repository.
     </a>
     You can also come talk to us on the
     <a href="https://discord.gg/FFYDNp5" target="_blank">Svelte discord</a>

--- a/src/pages/help/components.svx
+++ b/src/pages/help/components.svx
@@ -12,11 +12,11 @@ You have to add your component in [components.json](https://github.com/svelte-so
 
 ## Forking the project
 
-You can fork the [Github project](https://github.com/svelte-society/sveltesociety.dev/), add your component and then propose a Pull request.
+You can fork the [GitHub project](https://github.com/svelte-society/sveltesociety.dev/), add your component and then propose a Pull request.
 
 ## Edit the file
 
-You can edit and propose your changes [directly in Github](https://github.com/svelte-society/sveltesociety.dev/edit/master/src/pages/components/components.json)
+You can edit and propose your changes [directly in GitHub](https://github.com/svelte-society/sveltesociety.dev/edit/master/src/pages/components/components.json)
 
 <hr />
 

--- a/src/pages/recipes/_layout.svelte
+++ b/src/pages/recipes/_layout.svelte
@@ -43,8 +43,7 @@
       }
   }
   :global(article blockquote) {
-    background: #ff3e01;
-    opacity: 0.2;
+    background: rgba(255, 62, 1, 0.2);
     border-radius: 5px 0px 0px 5px;
     color: black;
     border-left: 2px solid #ff3e01;


### PR DESCRIPTION
The axe accessibility checker was reporting multiple [color contrast violations](https://dequeuniversity.com/rules/axe/3.5/color-contrast?application=AxeChrome). This could make text on the site hard to read for people with low vision.

This PR updates the colors on links, code samples, and blockquotes to meet the WCAG AA guidelines. Below are images of before and after.

I also made the capitalization of GitHub consistent while I was in there 😄 

## Links
Before:
![image](https://user-images.githubusercontent.com/4992896/104486083-1fa4c900-5580-11eb-90c7-d899062182b2.png)

After:
![image](https://user-images.githubusercontent.com/4992896/104486111-27646d80-5580-11eb-81da-5c3967025921.png)

## Blockquote
Before (https://sveltesociety.dev/recipes/build-setup/writing-your-own-preprocessors):
![image](https://user-images.githubusercontent.com/4992896/104486175-3ba86a80-5580-11eb-9317-e20fc3388cda.png)

After:
![image](https://user-images.githubusercontent.com/4992896/104486215-47942c80-5580-11eb-8a01-bc7b7477b023.png)

## Code samples
Before:
![image](https://user-images.githubusercontent.com/4992896/104486439-9cd03e00-5580-11eb-84dd-0cb3be5a76a1.png)

After:
![image](https://user-images.githubusercontent.com/4992896/104486411-93df6c80-5580-11eb-9e10-481b25b41e9d.png)
