### PR TITLE
improve the events//societys section and add a licenses page

### DIFF
--- a/.routify/routes.js
+++ b/.routify/routes.js
@@ -1,11 +1,11 @@
 
 /**
  * @roxi/routify 2.8.5
- * File generated Thu Jan 14 2021 17:43:14 GMT+0100 (Mitteleuropäische Normalzeit)
+ * File generated Sat Jan 16 2021 12:10:09 GMT+0100 (Mitteleuropäische Normalzeit)
  */
 
 export const __version = "2.8.5"
-export const __timestamp = "2021-01-14T16:43:14.446Z"
+export const __timestamp = "2021-01-16T11:10:09.825Z"
 
 //buildRoutes
 import { buildClientTree } from "@roxi/routify/runtime/buildRoutes"
@@ -180,7 +180,7 @@ export const _tree = {
             "frontmatter": {
               "title": "Svelte Society Day 2020 France",
               "layout": "eventPage",
-              "date": "27.09.2020",
+              "date": "2020-09-27",
               "isPast": true
             },
             "recursive": true,
@@ -236,7 +236,7 @@ export const _tree = {
             "frontmatter": {
               "title": "Svelte Society Day 2020",
               "layout": "eventPage",
-              "date": "26.04.2020",
+              "date": "2020-04-26",
               "isPast": true
             },
             "recursive": true,
@@ -267,7 +267,7 @@ export const _tree = {
             "frontmatter": {
               "title": "Svelte Summit 2020",
               "layout": "eventPage",
-              "date": "18.10.2020",
+              "date": "2020-10-18",
               "isPast": true
             },
             "recursive": true,
@@ -371,6 +371,34 @@ export const _tree = {
       "path": "/index",
       "id": "_index",
       "component": () => import('../src/pages/index.svelte').then(m => m.default)
+    },
+    {
+      "isFile": true,
+      "isDir": false,
+      "file": "licenses.svx",
+      "filepath": "/licenses.svx",
+      "name": "licenses",
+      "ext": "svx",
+      "badExt": false,
+      "absolutePath": "/Users/dietrich/Desktop/dev/contrib/sveltesociety.dev/src/pages/licenses.svx",
+      "importPath": "../src/pages/licenses.svx",
+      "isLayout": false,
+      "isReset": false,
+      "isIndex": false,
+      "isFallback": false,
+      "isPage": true,
+      "ownMeta": {},
+      "meta": {
+        "frontmatter": {
+          "title": "License information"
+        },
+        "recursive": true,
+        "preload": false,
+        "prerender": true
+      },
+      "path": "/licenses",
+      "id": "_licenses",
+      "component": () => import('../src/pages/licenses.svx').then(m => m.default)
     },
     {
       "isFile": true,

--- a/.routify/urlIndex.json
+++ b/.routify/urlIndex.json
@@ -7,6 +7,7 @@
   "/events/summit2020",
   "/help/components",
   "/index",
+  "/licenses",
   "/recipes/build-setup/transpiling-es6-to-es5-for-legacy-browser-support",
   "/recipes/build-setup/using-future-js-syntax-in-svelte-using-babel",
   "/recipes/build-setup/using-postcss-with-svelte",

--- a/src/pages/about/index.svx
+++ b/src/pages/about/index.svx
@@ -9,7 +9,6 @@ Svelte Society is the global Svelte community organization. It started as a seri
 - Twitter: https://twitter.com/sveltesociety
 - [~20 meetups across 3 continents](https://twitter.com/SvelteSociety/status/1235264100600631296?s=20)
 
-
 ## Svelte Society Code of Conduct
 
 All interaction on any platform associated with Svelte Society is subject to a Code of Conduct, enforced by Svelte maintainers and Svelte Society organizers. Even though it'd be great if we lived in a world where this wasn't an issue, Code of Conducts are required to ensure that everyone can attend events without reservations.
@@ -28,7 +27,6 @@ Harassment includes offensive verbal or written comments related to sex, gender 
 
 If a community member engages in harassing behavior, Svelte Society organizers may take any action they deem appropriate, including warning the offender, expulsion from the Svelte Society community, and/or removal from an event. If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a Svelte Society organizer immediately, or as soon as you feel comfortable doing so.
 
-
 ### Diversity and Inclusion
 
 Svelte is for everyone. Svelte Society understands that it needs to have representative voices from a range of diverse backgrounds for the Svelte community to thrive. This is reflected in the Svelte Society Discord and Twitter.
@@ -38,3 +36,7 @@ However, a lot of work remains to be done. The original Svelte Society meetups a
 ### Acknowledgements
 
 Special thanks to [VueMeetups](https://events.vuejs.org/code-of-conduct/#english) for the basis of this Code of Conduct.
+
+## License information
+
+The license information can be found [here](https://sveltesociety.dev/licenses).

--- a/src/pages/events/frsocietyday2020.svx
+++ b/src/pages/events/frsocietyday2020.svx
@@ -1,7 +1,7 @@
 ---
 title: Svelte Society Day 2020 France
 layout: eventPage
-date: 27.09.2020
+date: 2020-09-27
 isPast: true
 ---
 

--- a/src/pages/events/index.svelte
+++ b/src/pages/events/index.svelte
@@ -1,6 +1,14 @@
 <script>
   import { layout, url } from "@roxi/routify";
   import societys from "./societys.json";
+
+  let events = $layout.children;
+  console.log(events);
+
+  let sortedEvents = events.sort(
+    (a, b) =>
+      Date.parse(b.meta.frontmatter.date) - Date.parse(a.meta.frontmatter.date)
+  );
 </script>
 
 <svelte:head>
@@ -9,7 +17,7 @@
 
 <div class="wrapper">
   <div class="event-wrapper">
-    {#each $layout.children as node}
+    {#each sortedEvents as node}
       <figure class="event-tile">
         {#if node.meta.frontmatter.isPast === true}
           <span class="past-event">Past event</span>
@@ -24,7 +32,7 @@
     {#each societys as society}
       <p class="society">{society.country}</p>
       {#if society.twitter}
-        <p>
+        <span class="twitter-wrapper">
           <svg
             class="twittericon"
             viewBox="0 0 21 16"
@@ -35,7 +43,7 @@
             /></svg
           >
           <a href="https://twitter.com/{society.twitter}">{society.twitter}</a>
-        </p>
+        </span>
       {/if}
 
       <ul class="society">
@@ -75,12 +83,18 @@
   p.society {
     margin-bottom: 0;
   }
+  .twitter-wrapper {
+    padding: 4px 20px;
+    display: flex;
+    justify-items: start;
+  }
   .twittericon {
-    padding-top: 5px;
+    padding-right: 4px;
     width: 19px;
     height: 19px;
     color: #60a5fa;
     fill: currentColor;
+    place-self: center;
   }
   .event-tile {
     --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1),

--- a/src/pages/events/index.svelte
+++ b/src/pages/events/index.svelte
@@ -16,6 +16,7 @@
 </svelte:head>
 
 <div class="wrapper">
+  <!--event section-->
   <div class="event-wrapper">
     {#each sortedEvents as node}
       <figure class="event-tile">
@@ -27,19 +28,27 @@
       </figure>
     {/each}
   </div>
+  <!--society section-->
   <div class="society-wrapper">
     <h5>Societys arround the world</h5>
     {#each societys as society}
       <p class="society">{society.country}</p>
       {#if society.twitter}
-        <span class="twitter-wrapper">
+        <span class="icon-wrapper">
           <svg
-            class="twittericon"
-            viewBox="0 0 21 16"
             xmlns="http://www.w3.org/2000/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+            aria-hidden="true"
+            role="img"
+            class="svgicon twitter"
             stroke="currentColor"
+            width="1em"
+            height="1em"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 24 24"
             ><path
-              d="M20.3 2c-.7.3-1.5.4-2.4.5A3.8 3.8 0 0019.7.3c-.8.5-1.7.8-2.6 1a4.2 4.2 0 00-3-1.3 4.2 4.2 0 00-2.9 1.2 4 4 0 00-1 3.7A12.3 12.3 0 011.5.7 3.8 3.8 0 002.8 6c-.7 0-1.3-.2-1.9-.5 0 1 .3 1.9 1 2.6.5.7 1.4 1.2 2.3 1.3l-1 .1h-.9c.3.7.8 1.4 1.5 2 .6.4 1.5.7 2.3.8A8.4 8.4 0 010 13.8a12 12 0 0014.6-1.6 11.3 11.3 0 003.4-8v-.5c1-.3 1.8-1 2.3-1.8z"
+              d="M22.162 5.656a8.384 8.384 0 0 1-2.402.658A4.196 4.196 0 0 0 21.6 4c-.82.488-1.719.83-2.656 1.015a4.182 4.182 0 0 0-7.126 3.814a11.874 11.874 0 0 1-8.62-4.37a4.168 4.168 0 0 0-.566 2.103c0 1.45.738 2.731 1.86 3.481a4.168 4.168 0 0 1-1.894-.523v.052a4.185 4.185 0 0 0 3.355 4.101a4.21 4.21 0 0 1-1.89.072A4.185 4.185 0 0 0 7.97 16.65a8.394 8.394 0 0 1-6.191 1.732a11.83 11.83 0 0 0 6.41 1.88c7.693 0 11.9-6.373 11.9-11.9c0-.18-.005-.362-.013-.54a8.496 8.496 0 0 0 2.087-2.165z"
+              fill="currentColor"
             /></svg
           >
           <a href="https://twitter.com/{society.twitter}">{society.twitter}</a>
@@ -48,6 +57,29 @@
 
       <ul class="society">
         <li><a href={society.url}>{society.name}</a></li>
+        {#if society.githuburl}
+          <ul style="list-style-type:none;">
+            <li>
+              <span class="icon-wrapper">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlns:xlink="http://www.w3.org/1999/xlink"
+                  aria-hidden="true"
+                  role="img"
+                  class="svgicon github"
+                  width="1em"
+                  height="1em"
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 24 24"
+                  ><path
+                    d="M12 2C6.475 2 2 6.475 2 12a9.994 9.994 0 0 0 6.838 9.488c.5.087.687-.213.687-.476c0-.237-.013-1.024-.013-1.862c-2.512.463-3.162-.612-3.362-1.175c-.113-.288-.6-1.175-1.025-1.413c-.35-.187-.85-.65-.013-.662c.788-.013 1.35.725 1.538 1.025c.9 1.512 2.338 1.087 2.912.825c.088-.65.35-1.087.638-1.337c-2.225-.25-4.55-1.113-4.55-4.938c0-1.088.387-1.987 1.025-2.688c-.1-.25-.45-1.275.1-2.65c0 0 .837-.262 2.75 1.026a9.28 9.28 0 0 1 2.5-.338c.85 0 1.7.112 2.5.337c1.912-1.3 2.75-1.024 2.75-1.024c.55 1.375.2 2.4.1 2.65c.637.7 1.025 1.587 1.025 2.687c0 3.838-2.337 4.688-4.562 4.938c.362.312.675.912.675 1.85c0 1.337-.013 2.412-.013 2.75c0 .262.188.574.688.474A10.016 10.016 0 0 0 22 12c0-5.525-4.475-10-10-10z"
+                    fill="currentColor"
+                  /></svg
+                ><a href={society.githuburl}>GitHub</a>
+              </span>
+            </li>
+          </ul>
+        {/if}
       </ul>
     {/each}
   </div>
@@ -83,18 +115,23 @@
   p.society {
     margin-bottom: 0;
   }
-  .twitter-wrapper {
-    padding: 4px 20px;
+  .icon-wrapper {
+    padding: 2px 20px;
     display: flex;
     justify-items: start;
   }
-  .twittericon {
+  .svgicon {
     padding-right: 4px;
-    width: 19px;
-    height: 19px;
+    width: 20px;
+    height: 20px;
     color: #60a5fa;
-    fill: currentColor;
     place-self: center;
+  }
+  .github {
+    color: #111827;
+  }
+  .twitter {
+    color: #60a5fa;
   }
   .event-tile {
     --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1),

--- a/src/pages/events/societyday2020.svx
+++ b/src/pages/events/societyday2020.svx
@@ -1,7 +1,7 @@
 ---
 title: Svelte Society Day 2020
 layout: eventPage
-date: 26.04.2020
+date: 2020-04-26
 isPast: true
 ---
 

--- a/src/pages/events/societys.json
+++ b/src/pages/events/societys.json
@@ -9,6 +9,12 @@
     "url": "https://www.downtomeet.com/Svelte-Dublin"
   },
   {
+    "name": "Sveltejs Meetup Hamburg",
+    "country": "🇩🇪 Germany",
+    "url": "https://www.meetup.com/de-DE/Svelte-js-Meetup-Hamburg/",
+    "githuburl": "https://github.com/svelte-meetup-hamburg/meetups/issues"
+  },
+  {
     "name": "Svelte Society Stockholm",
     "country": "🇸🇪 Sweden",
     "twitter":"@kevmodrome",

--- a/src/pages/events/summit2020.svx
+++ b/src/pages/events/summit2020.svx
@@ -1,7 +1,7 @@
 ---
 title: Svelte Summit 2020
 layout: eventPage
-date: 18.10.2020
+date: 2020-10-18
 isPast: true
 ---
 

--- a/src/pages/licenses.svx
+++ b/src/pages/licenses.svx
@@ -1,0 +1,211 @@
+---
+title: License information
+layout: recipe
+---
+
+This page uses the [Remix Icon pack](https://github.com/Remix-Design/RemixIcon) thats licensed under the
+Apache License 2.0:
+
+```txt
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+```


### PR DESCRIPTION
## Event section
- add sorting to events list (displaying newest date first)
- societys section
  - add german society
  - add the optional githublink property to `societys.json` what can be added to a society if this society is planning their events via github
  - add remixicons
### preview
![Screenshot_2021-01-16  Events - Svelte Society](https://user-images.githubusercontent.com/47633893/104810479-15d7cb80-57f5-11eb-85ec-2eb68e55c4b5.png)

## License page
- create License page and link to it at the about page
- add license of remixicons to license page
### preview
![Screenshot_2021-01-16  License information - Svelte Society](https://user-images.githubusercontent.com/47633893/104810494-3f90f280-57f5-11eb-9148-83be02410784.png)

