### PR TITLE
add responsivness to footer

### DIFF
--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -69,6 +69,20 @@
     max-width: unset;
     padding: 3em;
   }
+
+  @media only screen and (max-width: 768px) {
+    footer {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      max-width: unset;
+      padding: 2em;
+      font-size: 15px;
+    }
+    a.ghlink{
+      font-size: 15px;
+    }
+  } 
 </style>
 
 <div class="shaded" id="title">
@@ -91,11 +105,12 @@
 <slot />
 
 <footer class="shaded">
-  <div>© Svelte Society {year}</div>
+  <div>&copy; Svelte Society {year}</div>
 
   <div>
     Want to contribute? Pick up an issue on
     <a
+    class="ghlink"
       href="https://github.com/svelte-society/sveltesociety.dev"
       target="_blank">GitHub</a>!
   </div>


### PR DESCRIPTION
This little pr makes the footer responsive for mobile devices.

i just added a media query for devices with a smaller breakpoint than `768 px` and changed the flex direction of the footer at this query to `column` and adjusted the font size. Hope this can be helpful 😃 

## preview
### without this pr
![footer_before](https://user-images.githubusercontent.com/47633893/104838337-af1ce580-58ba-11eb-8a74-97c5c92ebde2.png)

### with this pr
![footer_responsive](https://user-images.githubusercontent.com/47633893/104838346-be9c2e80-58ba-11eb-8ba2-826f88865934.png)
