### PR TITLE
Performance improvement

### DIFF
--- a/assets/global.css
+++ b/assets/global.css
@@ -48,6 +48,11 @@
 	border-left: 4px solid var(--color-secondary);
 	padding: 0.01rem 0.8rem;
   }
+
+  html,
+  body {
+	  min-height: 100vh;
+  }
   
   body {
 	background: var(--color-bg);

--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -69,6 +69,20 @@
     max-width: unset;
     padding: 3em;
   }
+
+  @media only screen and (max-width: 768px) {
+    footer {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      max-width: unset;
+      padding: 2em;
+      font-size: 15px;
+    }
+    a.ghlink{
+      font-size: 15px;
+    }
+  } 
 </style>
 
 <div class="shaded" id="title">
@@ -91,11 +105,12 @@
 <slot />
 
 <footer class="shaded">
-  <div>© Svelte Society {year}</div>
+  <div>&copy; Svelte Society {year}</div>
 
   <div>
     Want to contribute? Pick up an issue on
     <a
+    class="ghlink"
       href="https://github.com/svelte-society/sveltesociety.dev"
       target="_blank">GitHub</a>!
   </div>

--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { metatags, page } from "@roxi/routify";
+  import { metatags, page, prefetch } from "@roxi/routify";
   metatags.template(
     "title",
     (title) => `${title ? ` ${title} - ` : ""}Svelte Society`
@@ -93,11 +93,11 @@
         <h1>SVELTE SOCIETY</h1>
       </div>
       <ul>
-        <li><a href="/">HOME</a></li>
-        <li><a href="/recipes">RECIPES</a></li>
-        <li><a href="/components">COMPONENTS</a></li>
-        <li><a href="/events">EVENTS</a></li>
-        <li><a href="/about">ABOUT</a></li>
+        <li><a href="/" use:prefetch>HOME</a></li>
+        <li><a href="/recipes" use:prefetch>RECIPES</a></li>
+        <li><a href="/components" use:prefetch>COMPONENTS</a></li>
+        <li><a href="/events" use:prefetch>EVENTS</a></li>
+        <li><a href="/about"use:prefetch>ABOUT</a></li>
       </ul>
     </nav>
   </header>


### PR DESCRIPTION
At the discord sveltesociety-website channel was following issue submitted by @alesvaupotic:

```
[...] I suggest a change to CSS on https://sveltesociety.dev/ to stop content shifting left-right? On Win10 Chrome at least, for the initial page, it happens while introduction.svg is loaded and page is not filling up the screen. Or while events are loading ... it's quite annoying. It can be min-height: 100vh on body or some other technique I never heard about before ... I noticed it doesn't happen on MacOS, though.
```
This PR 'should' resolve it (I haven't the right testing environment, I'm working on Mac), like @alesvaupotic suggested it, with applying a CSS min-height to the body and the html. I also added prefetch to the Nav elements, because in a [measurement](https://web.dev/measure) this was suggested to improve the performance of this site. I will add prefetch to the event section  soon, but actually I'm doing another feature there. Happy reviewing!