### PR TITLE
more performance with robots.txt file & rel="noopener" attributes

### DIFF
--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -1,0 +1,4 @@
+# Sitemap: https://sveltesociety.dev/sitemap.xml
+
+User-Agent: *
+Disallow: /fonts/

--- a/src/components/Introduction.svelte
+++ b/src/components/Introduction.svelte
@@ -20,17 +20,17 @@
     for prime-time! If you're interested in helping out checkout the
     <a
       href="https://github.com/svelte-society/sveltesociety.dev"
-      target="_blank">
+      target="_blank" rel="noopener">
       GitHub repository.
     </a>
     You can also come talk to us on the
-    <a href="https://discord.gg/FFYDNp5" target="_blank">Svelte discord</a>
+    <a href="https://discord.gg/FFYDNp5" target="_blank" rel="noopener">Svelte discord</a>
     if you want further guidance.
   </h2>
 
   <p>
     In the meantime, you can checkout
-    <a href="https://sveltesummit.com">Svelte Summit</a>, 
+    <a href="https://sveltesummit.com" rel="noopener">Svelte Summit</a>, 
     our previous online conference. It is free and we have all of the speaker's recorded talks available.
   </p>
   <img src="introduction.svg" alt="Live Conversation Application Preview" />

--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -112,6 +112,6 @@
     <a
     class="ghlink"
       href="https://github.com/svelte-society/sveltesociety.dev"
-      target="_blank">GitHub</a>!
+      target="_blank" rel="noopener">GitHub</a>!
   </div>
 </footer>

--- a/src/pages/events/index.svelte
+++ b/src/pages/events/index.svelte
@@ -47,13 +47,13 @@
         <li>
           <span class="icon-wrapper">
             <Icon name="globe" />
-            <a href={society.url}>{society.name}</a>
+            <a href={society.url} rel="noopener">{society.name}</a>
           </span>
         </li>
         {#if society.twitter}
           <span class="icon-wrapper">
             <Icon name="twitter" />
-            <a href="https://twitter.com/{society.twitter}">{society.twitter}</a
+            <a href="https://twitter.com/{society.twitter}" rel="noopener">{society.twitter}</a
             >
           </span>
         {/if}
@@ -63,7 +63,7 @@
             <li>
               <span class="icon-wrapper">
                 <Icon name="github" />
-                <a href={society.githuburl}>GitHub</a>
+                <a href={society.githuburl} rel="noopener">GitHub</a>
               </span>
             </li>
           </ul>


### PR DESCRIPTION
This pull request should resolve some issues from a lighthouse performance audit that can be found [here](https://lighthouse-dot-webdotdevsite.appspot.com//lh/html?url=https%3A%2F%2Fsveltesociety.dev). I commented the sitemap at `robots.txt` because I wasn't able to find a good solution to auto generate one. Maybe I can resolve this in the future.