### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-21 [these people](https://github.com/svelte-society/sveltesociety.dev/graphs/contributors)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -46,3 +46,7 @@ This is regular text
   Click <a href="/">here</a> to read more about this.
 </ReadMore>
 ```
+
+## License
+
+[MIT](LICENSE)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "svelte-society",
   "description": "Svelte Society Website",
   "version": "0.2.0",
+  "license": "MIT",
   "@comments scripts": {
     "dev": "develop with blazing fast rebuilds",
     "dev:features": "develop with features like SSR and serviceworker enabled",


### PR DESCRIPTION
Running `yarn` logged a warning:
> warning package.json: No license field

Not having a license means technically, [no one can legally copy/modify the code](https://choosealicense.com/no-permission/):
> When you make a creative work (which includes code), the work is under exclusive copyright by default. Unless you include a license that specifies otherwise, nobody else can copy, distribute, or modify your work without being at risk of take-downs, shake-downs, or litigation. Once the work has other contributors (each a copyright holder), “nobody” starts including you.

I added the [MIT License](https://choosealicense.com/licenses/mit/) to the project -- it's simple and permissive, and it's the same one Svelte uses. 