### PR TITLE
Nav QOL + title

### DIFF
--- a/src/components/layout/Nav.svelte
+++ b/src/components/layout/Nav.svelte
@@ -1,7 +1,5 @@
 <script>
   import { prefetch, isActive, url } from "@roxi/routify";
-  console.log($isActive("/cheat"));
-
   const links = [
     ["/index", "home"],
     ["/recipes", "recipes"],

--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -5,7 +5,7 @@
 
   metatags.template(
     "title",
-    (title) => `${title ? ` ${title} - ` : ""}Svelte Society`
+    (title) => `${title=='Index' ? ` Home` :`${title}`} - Svelte Society`
   );
   const capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1);
   $: metatags.title = capitalize($page.title);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3922469/105378366-c00a8580-5c31-11eb-9230-319fe912eda4.png)

The title at home page shows `Index` 😆  this fixes instead shows `Home - Svelte Society` 

also removed the `console.log` #133