### PR TITLE
fix the bug at the recipes section

### DIFF
--- a/src/layouts/Recipe.svelte
+++ b/src/layouts/Recipe.svelte
@@ -1,5 +1,11 @@
 <script>
-  import { metatags } from "@roxi/routify";
+  import { metatags, layout, page } from "@roxi/routify";
+  import CategoryTree from "@/components/recipes/CategoryTree.svelte";
+  const nodes = $layout.children;
+
+  const categories = nodes.map(
+    (node) => node.children.filter((r) => r.path.includes("/index"))[0]
+  );
   export let title,
     description = "";
 
@@ -10,6 +16,68 @@
   $: metatags["twitter:description"] = description;
 </script>
 
-<h1>{title}</h1>
+<main>
+  <div class="TOC">
+    <h1>Table of Contents</h1>
+    {#each categories as node}
+      <div class="TOCLink" class:active={$page.path.includes(node.parent.path)}>
+        <img src={node.meta.frontmatter.icon} alt="" />
+        <a href={node.parent.path}>{node.meta.frontmatter.title}</a>
+      </div>
+      {#if $page.path.includes(node.parent.path)}
+        <CategoryTree nodes={node.parent.children} />
+      {/if}
+    {/each}
+  </div>
+  <article>
+    <h1>{title}</h1>
+    <slot />
+  </article>
+</main>
 
-<slot />
+<style>
+  .TOCLink {
+    align-items: baseline;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-gap: 10px;
+    padding: 1rem 0;
+    border-bottom: 1px solid #d0deec;
+    font-size: 1.1em;
+  }
+  .TOCLink.active a {
+    font-weight: bold;
+  }
+  .TOCLink img {
+    height: 1em;
+  }
+  @media (min-width: 1024px) {
+    main {
+      display: flex;
+    }
+  }
+  main {
+    margin: 0 auto;
+    max-width: var(--width-content);
+    padding: 2rem 1rem;
+  }
+  .TOC {
+    margin-right: 2rem;
+    flex: 1;
+    font-family: Overpass;
+    line-height: 150%;
+  }
+  .TOC :global(a) {
+    color: #2e2e35;
+    font-weight: normal;
+  }
+  article {
+    flex: 3;
+    overflow-x: hidden;
+  }
+  @media (min-width: 1024px) {
+    article {
+      margin-left: 2rem;
+    }
+  }
+</style>

--- a/src/layouts/RecipeCategory.svelte
+++ b/src/layouts/RecipeCategory.svelte
@@ -1,6 +1,15 @@
 <script>
-  import { page, metatags } from "@roxi/routify";
-  const nodes = $page.parent.children.filter(r => !r.path.includes("/index"));
+  import { metatags, layout, page } from "@roxi/routify";
+  import CategoryTree from "@/components/recipes/CategoryTree.svelte";
+  const nodes = $layout.children;
+
+  const categories = nodes.map(
+    (node) => node.children.filter((r) => r.path.includes("/index"))[0]
+  );
+  const childrenNodes = $page.parent.children.filter(
+    (r) => !r.path.includes("/index")
+  );
+
   export let title,
     description = "";
 
@@ -11,14 +20,76 @@
   $: metatags["twitter:description"] = description;
 </script>
 
-<h1>{title}</h1>
+<main>
+  <div class="TOC">
+    <h1>Table of Contents</h1>
+    {#each categories as node}
+      <div class="TOCLink" class:active={$page.path.includes(node.parent.path)}>
+        <img src={node.meta.frontmatter.icon} alt="" />
+        <a href={node.parent.path}>{node.meta.frontmatter.title}</a>
+      </div>
+      {#if $page.path.includes(node.parent.path)}
+        <CategoryTree nodes={node.parent.children} />
+      {/if}
+    {/each}
+  </div>
+  <article>
+    <h1>{title}</h1>
+    <slot />
 
-<slot />
+    <ul>
+      {#each childrenNodes as node}
+        <li>
+          <a href={node.path}>{node.meta.frontmatter.title}</a>
+        </li>
+      {/each}
+    </ul>
+  </article>
+</main>
 
-<ul>
-  {#each nodes as node}
-    <li>
-      <a href={node.path}>{node.meta.frontmatter.title}</a>
-    </li>
-  {/each}
-</ul>
+<style>
+  .TOCLink {
+    align-items: baseline;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-gap: 10px;
+    padding: 1rem 0;
+    border-bottom: 1px solid #d0deec;
+    font-size: 1.1em;
+  }
+  .TOCLink.active a {
+    font-weight: bold;
+  }
+  .TOCLink img {
+    height: 1em;
+  }
+  @media (min-width: 1024px) {
+    main {
+      display: flex;
+    }
+  }
+  main {
+    margin: 0 auto;
+    max-width: var(--width-content);
+    padding: 2rem 1rem;
+  }
+  .TOC {
+    margin-right: 2rem;
+    flex: 1;
+    font-family: Overpass;
+    line-height: 150%;
+  }
+  .TOC :global(a) {
+    color: #2e2e35;
+    font-weight: normal;
+  }
+  article {
+    flex: 3;
+    overflow-x: hidden;
+  }
+  @media (min-width: 1024px) {
+    article {
+      margin-left: 2rem;
+    }
+  }
+</style>

--- a/src/pages/recipes/_layout.svelte
+++ b/src/pages/recipes/_layout.svelte
@@ -1,96 +1,31 @@
 <script>
   import CategoryTree from "@/components/recipes/CategoryTree.svelte";
-  import { setContext } from 'svelte'
+  import { setContext } from "svelte";
 
   import { layout, page } from "@roxi/routify";
   const nodes = $layout.children;
 
   const categories = nodes.map(
-    node => node.children.filter(r => r.path.includes("/index"))[0]
+    (node) => node.children.filter((r) => r.path.includes("/index"))[0]
   );
 
-  setContext('categories', categories)
+  setContext("categories", categories);
 </script>
 
+<svelte:head>
+  <title>Svelte Recipes</title>
+  <link rel="stylesheet" href="/prism.css" />
+</svelte:head>
+
+<div class="home-wrap">
+  <slot />
+</div>
+
 <style>
-  @media (min-width: 1024px) {
-      main {
-        display: flex;
-      }
-  }
-  main {
-    margin: 0 auto;
-    max-width: var(--width-content);
-    padding: 2rem 1rem;
-  }
-  .TOC {
-    margin-right: 2rem;
-    flex: 1;
-    font-family: Overpass;
-    line-height: 150%;
-  }
-  .TOC :global(a) {
-    color: #2e2e35;
-    font-weight: normal;
-  }
-  article {
-    flex: 3;
-    overflow-x: hidden;
-  }
-  @media (min-width: 1024px) {
-      article {
-        margin-left: 2rem;
-      }
-  }
   :global(article blockquote) {
     background: rgba(255, 62, 1, 0.2);
     border-radius: 5px 0px 0px 5px;
     color: black;
     border-left: 2px solid #ff3e01;
   }
-  .TOCLink {
-    align-items: baseline;
-    display: grid;
-    grid-template-columns: auto 1fr;
-    grid-gap: 10px;
-    padding: 1rem 0;
-    border-bottom: 1px solid #d0deec;
-    font-size: 1.1em;
-  }
-  .TOCLink.active a {
-    font-weight: bold;
-  }
-  .TOCLink img {
-    height: 1em;
-  }
-
- 
 </style>
-
-<svelte:head>
-  <title>Svelte Recipes</title>
-  <link rel="stylesheet" href="/prism.css">
-</svelte:head>
-{#if $page.path !== "/recipes/index"}
-  <main>
-    <div class="TOC">
-      <h1>Table of Contents</h1>
-      {#each categories as node}
-        <div class="TOCLink" class:active={$page.path.includes(node.parent.path)}>
-          <img src={node.meta.frontmatter.icon} alt="" />
-          <a href={node.parent.path}>{node.meta.frontmatter.title}</a>
-        </div>
-        {#if $page.path.includes(node.parent.path)}
-          <CategoryTree nodes={node.parent.children} />
-        {/if}
-      {/each}
-    </div>
-    <article>
-      <slot />
-    </article>
-  </main>
-{:else}
-  <div class="home-wrap">
-    <slot />
-  </div>
-{/if}


### PR DESCRIPTION
At the recipe section you can find following bug by doing these steps:
1. Go to the recipes section by clicking `RECIPES` at the Navbar
2. Klick on `Build Setup`
3. Now do step 1
With doing step 3 the recipe page doesn't show up. This PR fix this bug what based on the circumstances, that `meta.frontmatter isn't found`.

This PR removes the unnecessary logic from `_layout.svelte` and extracts it to the Recipe layouts. I hope this doesn't only work on my machine 😃 