### PR TITLE
Auto update component star counts using a Github action

### DIFF
--- a/.github/workflows/update-stars.yml
+++ b/.github/workflows/update-stars.yml
@@ -1,0 +1,26 @@
+name: Update component stars
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # once a day
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          ref: staging
+      - name: Install
+        run: |
+          touch .env
+          echo GITHUB_TOKEN=${{secrets.GITHUB_TOKEN}} >> .env
+          npm install dotenv node-fetch
+          git checkout package-lock.json
+      - name: Fetch
+        run: node update-stars.js
+      - name: Store
+        uses: mikeal/publish-to-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: staging

--- a/.github/workflows/update-stars.yml
+++ b/.github/workflows/update-stars.yml
@@ -18,7 +18,7 @@ jobs:
           npm install dotenv node-fetch
           git checkout package-lock.json
       - name: Fetch
-        run: node update-stars.js
+        run: node scripts/update-stars.js
       - name: Store
         uses: mikeal/publish-to-github-action@master
         env:

--- a/scripts/update-stars.js
+++ b/scripts/update-stars.js
@@ -4,10 +4,7 @@ const path = require("path");
 const fetch = require("node-fetch");
 require("dotenv").config();
 
-const pathToData = path.join(
-  __dirname,
-  "/src/pages/components/components.json"
-);
+const pathToData = path.resolve("./src/pages/components/components.json");
 const components = JSON.parse(fs.readFileSync(pathToData));
 
 (async function () {

--- a/update-stars.js
+++ b/update-stars.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+const fetch = require("node-fetch");
+require("dotenv").config();
+
+const pathToData = path.join(
+  __dirname,
+  "/src/pages/components/components.json"
+);
+const components = JSON.parse(fs.readFileSync(pathToData));
+
+(async function () {
+  for (component of components) {
+    let { url } = component;
+
+    if (url.includes("https://github.com")) {
+      const splitURL = url.split("/");
+      const user = splitURL[3];
+      const repo = splitURL[4];
+
+      await fetch(`https://api.github.com/repos/${user}/${repo}`, {
+        headers: { Authorization: `token ${process.env.GITHUB_TOKEN}` },
+      })
+        .then((res) => res.json())
+        .then(({ stargazers_count }) => {
+          if (stargazers_count) {
+            component.stars = stargazers_count;
+          }
+        });
+    }
+  }
+
+  fs.writeFileSync(
+    path.resolve(pathToData),
+    JSON.stringify(components, null, 2)
+  );
+})();


### PR DESCRIPTION
This PR uses a GitHub action to update the star count of every component once a day. Closes https://github.com/svelte-society/sveltesociety.dev/issues/94 . Currently only works for components hosted on GitHub, although almost all of them are.  I wasn't sure where the best place was to put `update-stars.js` ? Thanks!