### PR TITLE
(Cheatsheet) design

### DIFF
--- a/assets/global.css
+++ b/assets/global.css
@@ -4,7 +4,7 @@
   --border-radius: 5px;
   --box-shadow: 2px 2px 10px;
   --code-fs: 1rem;
-  --color: #ff3e00;
+  --color: #f97316;
   --color-accent: #ff3e000b;
   --color-bg: #fff;
   --color-bg-secondary: #e9e9e9;
@@ -29,6 +29,7 @@
   --svelte-grey-light: #d1d1d1;
 
   --m18: 1.125rem;
+  --m15: 0.9375rem;
   --m10: 0.625rem;
   --m5: 0.3125rem;
   --m1: 0.0625rem;
@@ -776,4 +777,10 @@ code {
 }
 .d-flex {
   display: flex;
+}
+
+@media print {
+  body {
+    border-top: none;
+  }
 }

--- a/src/components/CheatSheetCard.svelte
+++ b/src/components/CheatSheetCard.svelte
@@ -1,23 +1,38 @@
 <script>
-  export let title = ''
+  export let title = "";
 </script>
-  
+
+<div class="card">
+  <header class="title">
+    <h2>{title}</h2>
+    <span class="circles" />
+  </header>
+  <section>
+    <slot>Content</slot>
+  </section>
+</div>
+
 <style>
   .card {
-    box-shadow: -5px 5px 5px rgba(0, 0, 0, 0.3);
-    border: var(--m1) solid var(--color);
+    --tw-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1),
+      0 10px 10px -5px rgba(0, 0, 0, 0.04);
+    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+      var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+    border: var(--m1) transparent var(--color);
+    border-radius: 10px;
     width: fit-content;
   }
 
   .card > .title {
-    background-color: var(--color);
+    background-color: #0284c7;
     padding: var(--m10);
-    color: #ffffff;    
+    color: #ffffff;
     display: flex;
     justify-content: space-between;
     align-items: center;
     height: 48px;
     max-width: 100%;
+    border-radius: 10px 10px 0px 0px;
   }
 
   .title > h2 {
@@ -29,11 +44,10 @@
 
   .title > .circles {
     display: block;
-    width: var(--m18);
-    height: var(--m18);
+    width: var(--m15);
+    height: var(--m15);
     border-radius: 50%;
     background-color: var(--color-red);
-    border: 1px solid #fff;
     box-shadow: 25px 0 0 0 var(--color-yellow), 50px 0 0 0 var(--color-green);
     margin-right: 50px;
     margin-left: 20px;
@@ -41,25 +55,86 @@
 
   .card > section {
     display: block;
-    padding: var(--m10);
+    background: none;
     height: calc(100% - 48px);
     overflow-x: auto;
-    font-size: 0.8rem;
+    font-size: 0.9rem;
+    padding: 5px;
+  }
+
+  section > :global(pre.hljs) {
+    background: none;
+    line-height: 1.5;
   }
 
   @media (max-width: 484px) {
     .title > h2 {
-      font-size: 0.8em;
+      font-size: 0.9em;
+    }
+    .card > section {
+      font-size: 0.7rem;
+    }
+  }
+
+  @media print {
+    @page {
+      margin: 0.5cm;
+    }
+    .card,
+    .card > .title,
+    .title > h2,
+    .card > section,
+    section > :global(pre.hljs),
+    :global(code) {
+      page-break-inside: avoid;
+    }
+    .card {
+      --tw-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1),
+        0 10px 10px -5px rgba(0, 0, 0, 0.04);
+      box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+        var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+      border: var(--m1) transparent var(--color);
+      border-radius: 10px;
+      width: fit-content;
+      page-break-before: auto;
+      page-break-after: auto;
+    }
+
+    .card > .title {
+      background-color: var(--color-secondary);
+      padding: var(--m5);
+      color: var(--color-text-secondary);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      height: 48px;
+      max-width: 100%;
+      border-radius: 10px 10px 0px 0px;
+    }
+
+    .title > h2 {
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+      font-size: 1em;
+    }
+
+    .title > .circles {
+      display: none;
+    }
+
+    .card > section {
+      display: block;
+      background: none;
+      height: calc(100% - 48px);
+      overflow-x: auto;
+      font-size: 0.5rem;
+      padding: 3px;
+    }
+
+    section > :global(pre.hljs) {
+      line-height: 1.25;
+      background: none;
     }
   }
 </style>
-
-<div class="card">
-  <header class="title">
-    <h2>{title}</h2>
-    <span class="circles" />
-  </header>
-  <section>
-    <slot>Content</slot>
-  </section>
-</div>

--- a/src/components/layout/Footer.svelte
+++ b/src/components/layout/Footer.svelte
@@ -50,4 +50,9 @@
       font-size: 15px;
     }
   }
+  @media print {
+    footer {
+      display: none;
+    }
+  }
 </style>

--- a/src/components/layout/Nav.svelte
+++ b/src/components/layout/Nav.svelte
@@ -84,4 +84,10 @@
     width: 92px;
     height: 92px;
   }
+
+  @media print {
+    .shaded{
+      display: none;
+    }
+  }
 </style>


### PR DESCRIPTION
Based on issue #139 I tried to improvethe design of the cheatsheet page. I've done following:

- I removed Nav and Footer from the page at `print` media querys
- I adjusted the design of the cheatsheet page:
  - other color
  - typography adjustments
  - shadow adjustments
  - I removed the lightgrey background of the codeblock
 
I also adjusted the primary color to a less 'agressive' orange.
I want that this design is ok to much people as possible, so please give me feedback if I missed something.

<b>The print media query actually seems to bug sometimes related to the browser you use. I don't know yet, what is missed at the code, so if you have experience with this, please take a look.</b>


## preview
![Screenshot_2021-01-27 Cheatsheet - Svelte Society(1)](https://user-images.githubusercontent.com/47633893/106036900-3564d300-60d6-11eb-81a1-80312ce0b933.png)
