### PR TITLE
Merge duplicate tags: "form" and "forms"

### DIFF
--- a/src/pages/components/components.json
+++ b/src/pages/components/components.json
@@ -276,7 +276,7 @@
     "stars": 62,
     "tags": [
       "components and libraries",
-      "form",
+      "forms",
       "forms and validation",
       "reactive forms",
       "validation"


### PR DESCRIPTION
This one component was tagged with "form" whereas "forms" is more widely used

This helps with https://github.com/svelte-society/sveltesociety.dev/issues/218 though more is left to do