### PR TITLE
Add Anchor link on component categories and on components' card

### DIFF
--- a/assets/global.css
+++ b/assets/global.css
@@ -286,6 +286,17 @@ a i {
   padding: 1rem 2rem;
 }
 
+a[href^="#"] {
+  color: var(--color-text-secondary);
+  visibility: hidden;
+}
+a[href^="#"]:hover {
+  text-decoration: none;
+}
+*:hover > a[href^="#"] {
+  visibility: visible;
+}
+
 /* Images */
 figure {
   margin: 0;

--- a/src/components/ComponentIndex/Card.svelte
+++ b/src/components/ComponentIndex/Card.svelte
@@ -65,12 +65,12 @@
   }
 </style>
 
-<div class="card" class:active>
+<div class="card" class:active id="component-{window.escape(title)}">
   {#if image}
     <img src={image} alt={title} />
   {/if}
   <h1>
-    <a href={url}>{title}</a>
+    <a href={url}>{title}</a> <a href="#component-{window.escape(title)}">#</a>
     {#if npm}<Tag click={() => copyToClipboard(`npm install ${npm}`)} variant="copy" title="npm install {npm}"/>{/if}
   </h1>
   <p class="flex-grow">{description}</p>

--- a/src/components/ComponentIndex/CardList.svelte
+++ b/src/components/ComponentIndex/CardList.svelte
@@ -38,7 +38,7 @@
 </style>
 
 <div class="list">
-  <h1>{title}</h1>
+  <h1 id="category-{window.escape(title)}">{title} <a href="#category-{window.escape(title)}">#</a></h1>
   <div class="grid">
     <slot />
   </div>


### PR DESCRIPTION
I found myself often stuck with the response "Look at the components page on SvelteSociety website and search for component X" or unable to point out a specific component.

This PR add an anchor on every category and component (with a link to this anchor) to solve this issue.