### PR TITLE
fix: Mark past event as past, Societys -> Societies

### DIFF
--- a/src/pages/events/2021-summit-spring.svx
+++ b/src/pages/events/2021-summit-spring.svx
@@ -2,6 +2,7 @@
 title: Svelte Summit Spring 2021
 layout: eventPage
 date: 2021-04-25
+isPast: true
 ---
 
 Svelte Summit is an event dedicated to Svelte and everything that is happening in the community. The event will be a day of (exclusive) pre-recorded talks streamed online, syndicated on various platforms including [YouTube](https://youtube.com/SvelteSociety). Specific discussions about the talks and water-cooler chit-chat will be happening live in the [Svelte Discord server](https://discord.gg/daNtanDmsE).

--- a/src/pages/events/index.svelte
+++ b/src/pages/events/index.svelte
@@ -52,7 +52,7 @@
 
   <!--society section-->
   <div class="society-wrapper">
-    <h5>Societys arround the world</h5>
+    <h5>Societies arround the world</h5>
     {#each societies as society}
       {#if society.continent}
         <h6 class="continent">{society.continent}</h6>


### PR DESCRIPTION
Just lending a hand where I can -- an event from April wasn't marked as "past" (honestly, this seems like it should be automated? happy to add something to the rendering component to check if the date has past...). Also, on the same page, "Societies" was misspelled as "Societys".